### PR TITLE
improves docstring parser

### DIFF
--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -279,7 +279,6 @@ def parse_docs(klass):
 
     # regex to find parameter types
     type_regex = re.compile(r'^(\w+|\{.*\})|(?<=\`\~)(.*?)(?=\`)')
-    name_type_sep = re.compile(r'\s\:\s|\:\s')
 
     # goes back to front to register descriptions first ;-)
     # considers only the Parameters section

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -286,7 +286,7 @@ def parse_docs(klass):
     for line in doc_lines[par_i: end_param_line][::-1]:
         if name_type_sep.findall(line):
             par_name, others_ = name_type_sep.split(line)
-            par_type = [_ for _ in type_regex.findall(others_) if _][0]
+            par_type = [_ for _ in type_regex.findall(others_)[0] if _][0]
             params[par_name]['type'] = par_type
             params[par_name]['desc'] = ' '.join(desc_tmp[::-1])
             desc_tmp.clear()

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -29,7 +29,7 @@ from MDAnalysis.analysis.base import AnalysisBase
 # relevant modules used in this CLI factory
 # hydro* are removed here because they have a different folder/file structure
 # and need to be investigated separately
-skip_mods = ('hydrogenbonds', 'hbonds')
+skip_mods = ('base', 'hydrogenbonds', 'hbonds')
 relevant_modules = (_mod for _mod in __all__ if _mod not in skip_mods)
 
 # global dictionary storing the parameters for all Analysis classes
@@ -279,7 +279,7 @@ def parse_docs(klass):
 
     # regex to find parameter types
     type_regex = re.compile(r'^(\w+|\{.*\})|(?<=\`\~)(.*?)(?=\`)')
-    name_type_sep = re.compile(r'\s\:\s|\:\s|\:')
+    name_type_sep = re.compile(r'\s\:\s|\:\s')
 
     # goes back to front to register descriptions first ;-)
     # considers only the Parameters section

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -278,14 +278,15 @@ def parse_docs(klass):
     desc_tmp = []
 
     # regex to find parameter types
-    type_regex = re.compile(r'^(\w+|\{.*\})')
+    type_regex = re.compile(r'^(\w+|\{.*\})|(?<=\`\~)(.*?)(?=\`)')
+    name_type_sep = re.compile(r'\s\:\s|\:\s|\:')
 
     # goes back to front to register descriptions first ;-)
     # considers only the Parameters section
     for line in doc_lines[par_i: end_param_line][::-1]:
-        if ' : ' in line:
-            par_name, others_ = line.split(' : ')
-            par_type = type_regex.findall(others_)[0]
+        if name_type_sep.findall(line):
+            par_name, others_ = name_type_sep.split(line)
+            par_type = [_ for _ in type_regex.findall(others_) if _][0]
             params[par_name]['type'] = par_type
             params[par_name]['desc'] = ' '.join(desc_tmp[::-1])
             desc_tmp.clear()

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -284,8 +284,8 @@ def parse_docs(klass):
     # goes back to front to register descriptions first ;-)
     # considers only the Parameters section
     for line in doc_lines[par_i: end_param_line][::-1]:
-        if name_type_sep.findall(line):
-            par_name, others_ = name_type_sep.split(line)
+        if ' : ' in line:
+            par_name, others_ = line.split(' : ')
             par_type = [_ for _ in type_regex.findall(others_)[0] if _][0]
             params[par_name]['type'] = par_type
             params[par_name]['desc'] = ' '.join(desc_tmp[::-1])


### PR DESCRIPTION
Solves #22 

If:

```
universe : `~MDAnalysis.core.universe.Universe`
```

gives `MDAnalysis.core.universe.Universe`

Takes in consideration also ` : `, `: `, ` :`, and `:`. 

@PicoCentauri does this address it all? Can you make a local test?

Cheers,