### PR TITLE
Simplify and split run_analsis functions

### DIFF
--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -111,9 +111,8 @@ def create_CLI(cli_parser, interface_name, parameters):
     # adds analyze_data function as the default func parameter.
     # this is possible because the analyze_data function is equal to all
     # Analysis Classes
-    common_group.set_defaults(func=analyze_data)
-
-    common_group.set_defaults(analysis_callable=parameters["callable"])
+    # common_group.set_defaults(func=analyze_data)
+    # common_group.set_defaults(analysis_callable=parameters["callable"])
 
     common_group.add_argument(
         "-s",
@@ -203,7 +202,6 @@ def create_CLI(cli_parser, interface_name, parameters):
             )
         groups += len(opt_) * [optional_parameters_group]
 
-    action_dict = {True: "store_false", False: "store_true"}
     for group, (name, args_dict) in zip(groups, parameters_to_parse):
 
         # prepares parameters before add_argument
@@ -218,15 +216,15 @@ def create_CLI(cli_parser, interface_name, parameters):
             default = None
 
         name_par = "-" + name
-
         description = args_dict["desc"]
-
         if issubclass(type_, (list, tuple)):
             group.add_argument(
-                name_par, dest=name, nargs="+", default=default,
+                name_par,
+                dest=name,
+                default=default,
+                nargs="+",
                 help="{} (default: %(default)s)".format(description)
                 )
-
         elif issubclass(type_, dict):
             group.add_argument(
                 name_par,
@@ -235,16 +233,14 @@ def create_CLI(cli_parser, interface_name, parameters):
                 action=libcli.KwargsDict,
                 help=description,
                 )
-
         elif type_ is bool:
             group.add_argument(
                 name_par,
                 dest=name,
-                action=action_dict[default],
+                action="store_false" if default else "store_true",
                 default=default,
                 help=description,
                 )
-
         elif type_ is mda.AtomGroup:
             group.add_argument(
                 name_par,
@@ -253,14 +249,21 @@ def create_CLI(cli_parser, interface_name, parameters):
                 default=default,
                 help=description + " Use a MDAnalysis selection string."
                 )
-
         else:
             group.add_argument(
-                name_par, dest=name, type=type_, default=default,
-                help="{} (default: %(default)s)".format(description)
+                name_par,
+                dest=name,
+                type=type_,
+                default=default,
+                help=f"{description} (default: %(default)s)"
                 )
     return
 
+def create_universe():
+    pass
+
+def setup_analysis_parameters():
+    pass
 
 def analyze_data(
         # top and trajs need to be positional parameters in all CLIs

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -526,7 +526,7 @@ def main():
     # There is to much useless code execution done here:
     # 1. We do not have to setup all possible clients all the time.
     #    i.e. for `mdacli RMSD` only the RMSD client should be build.
-    # 2. for something like `mdacli -h` We do not have to build every 
+    # 2. for something like `mdacli -h` We do not have to build every
     #   sub parser in complete detail.
     setup_clients(ap, title="MDAnalysis Analysis CLI", members=members)
 

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -362,9 +362,9 @@ def convert_analysis_parameters(universe,
                                 analysis_callable,
                                 analysis_parameters):
     """
-    Convert parameters from the command line for the anlysis.
+    Convert parameters from the command line suitbale for anlysis.
 
-    Convert special types (i.e AtomGroups) from the command line
+    Special types (i.e AtomGroups) are concerted from the command line
     strings into the correct format. Parameters are changed inplace.
 
     The following types are converted:
@@ -377,7 +377,7 @@ def convert_analysis_parameters(universe,
     universe : `MDAnalysis.Universe`
         Universe for which the kwargs are related to
     analysis_callable : function
-        Analysis class for which the analysis is performed.
+        Analysis class for which the analysis should be performed.
     analysis_parameters : dict
         parameters to be processed
 
@@ -388,20 +388,17 @@ def convert_analysis_parameters(universe,
     """
     params = parse_docs(analysis_callable)[2]
     for param_name, dictionary in params.items():
-        if "AtomGroup" in dictionary['type']:
-            sel = universe.select_atoms(analysis_parameters[param_name])
-            if len(sel) > 0:
-                analysis_parameters[param_name] = sel
-            else:
-                raise ValueError(
-                    "AtomGroup `-{}` with selection `{}` does not "
-                    "contain any atoms".format(
-                        param_name,
-                        analysis_parameters[param_name]
-                        )
-                    )
-        elif "Universe" in dictionary['type']:
-            analysis_parameters[param_name] = universe
+        if param_name in analysis_parameters.keys():
+            if "AtomGroup" in dictionary['type']:
+                sel = universe.select_atoms(analysis_parameters[param_name])
+                if sel:
+                    analysis_parameters[param_name] = sel
+                else:
+                    raise ValueError(f"AtomGroup `-{param_name}` with selection"
+                                    f" `{analysis_parameters[param_name]}` does"
+                                    " not contain any atoms")
+            elif "Universe" in dictionary['type']:
+                analysis_parameters[param_name] = universe
 
 
 def maincli(ap):
@@ -460,13 +457,13 @@ def maincli(ap):
     ac.run(verbose=verbose, **arg_grouped_dict["Analysis run Parameters"])
 
     # Save the data
-    arg_grouped_dict["Saving Parameters"]["output_prefix"] += "_" \
-        if arg_grouped_dict["Saving Parameters"]["output_prefix"] else ""
-
     try:
         ac.save_results()
 
     except AttributeError:
+        arg_grouped_dict["Saving Parameters"]["output_prefix"] += "_" \
+            if arg_grouped_dict["Saving Parameters"]["output_prefix"] else ""
+
         save_results(
             ac.results,
             os.path.join(

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -97,8 +97,8 @@ def split_argparse_into_groups(parser, namespace):
     """
     Split the the populated namespace of argparse into groups.
 
-    See https://stackoverflow.com/questions/31519997/is-it-possible-to-only-parse-one-argument-groups-parameters-with-argparse
-    for details
+    https://stackoverflow.com/questions/31519997/is-it-possible-to-
+    only-parse-one-argument-groups-parameters-with-argparse
 
     Parameters
     ----------
@@ -114,8 +114,8 @@ def split_argparse_into_groups(parser, namespace):
     """
     arg_grouped_dict = {}
     for group in parser._action_groups:
-        group_dict={a.dest:getattr(namespace, a.dest, None)
-            for a in group._group_actions}
+        group_dict = {a.dest: getattr(namespace, a.dest, None)
+                      for a in group._group_actions}
         arg_grouped_dict[group.title] = group_dict
 
     return arg_grouped_dict

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -91,3 +91,31 @@ def find_AnalysisBase_members_ignore_warnings(modules):
         warnings.simplefilter('ignore')
         members = find_AnalysisBase_members(modules)
     return members
+
+
+def split_argparse_into_groups(parser, namespace):
+    """
+    Split the the populated namespace of argparse into groups.
+
+    See https://stackoverflow.com/questions/31519997/is-it-possible-to-only-parse-one-argument-groups-parameters-with-argparse
+    for details
+
+    Parameters
+    ----------
+    parse : `argparse.ArgumentParser`
+        argument parser instance
+    namespace : `argparse.Namespace`
+        instance storing the parameters
+
+    Returns
+    -------
+    arg_grouped_dict : dict
+        Dictionary containing parameters split according to their groups
+    """
+    arg_grouped_dict = {}
+    for group in parser._action_groups:
+        group_dict={a.dest:getattr(namespace, a.dest, None)
+            for a in group._group_actions}
+        arg_grouped_dict[group.title] = group_dict
+
+    return arg_grouped_dict

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,9 +15,11 @@ import pytest
 from MDAnalysis.analysis.rdf import InterRDF
 from MDAnalysisTests.datafiles import TPR, XTC
 from MDAnalysisTests.topology.test_lammpsdata import LAMMPS_NORESID
-from numpy.testing import assert_equal
+from MDAnalysisTests.core.test_universe import CHOL_GRO
 
-from mdacli.cli import _relevant_modules, run_analsis, setup_clients
+from mdacli.cli import _relevant_modules, setup_clients
+from mdacli.cli import create_universe
+
 from mdacli.libcli import find_AnalysisBase_members_ignore_warnings
 
 
@@ -46,7 +48,7 @@ def test_extra_options(args):
     'opt, dest, val',
     (('-s', "topology", "foo"),
      ('-top', "topology_format", "foo"),
-     ('-f', "trajectories", ["foo", "bar"]),
+     ('-f', "coordinates", ["foo", "bar"]),
      ('-traj', "trajectory_format", "foo"),
      ('-atom_style', "atom_style", "foo"),
      ('-b', "begin", 42),
@@ -68,78 +70,106 @@ def test_setup_clients(opt, dest, val):
         assert t(getattr(args, dest)) == val
 
 
-class Test_run_analsis(object):
-    """Test class for analyze_data."""
+class Test_create_Universe:
+    def test_create_universe(self):
+        u = create_universe(TPR, XTC)
+        assert len(u.atoms) == 47681
+        assert hasattr(u, "trajectory")
 
-    @pytest.fixture()
-    def kwargs(self):
-        """Keyword arguments for run."""
-        kwargs = {}
-        kwargs["topology"] = TPR
-        kwargs["topology_format"] = None
-        kwargs["trajectories"] = XTC
-        kwargs["trajectory_format"] = None
-        kwargs["atom_style"] = None
-        kwargs["begin"] = "0"
-        kwargs["end"] = "1"
-        kwargs["dt"] = "1"
-        kwargs["output_directory"] = "."
-        kwargs["output_prefix"] = ""
-        kwargs["verbose"] = False
-        kwargs["g1"] = "resid 500"  # water molecules
-        kwargs["g2"] = "resid 501"  # water molecules
+    def test_topology_format(self):
+        u = create_universe(StringIO(CHOL_GRO), topology_format="GRO")
+        assert len(u.atoms) == 8
 
-        kwargs["func"] = None
-        return kwargs
+    def test_create_universe_no_traj(self):
+        u = create_universe(TPR)
+        assert not hasattr(u, "trajectory")
 
-    def test_default(self, kwargs, tmpdir):
-        """Simple with default arguments."""
-        with tmpdir.as_cwd():
-            run_analsis(analysis_callable=InterRDF, **kwargs)
+    def test_trajectory_format(self):
+        u = create_universe(topology=StringIO(CHOL_GRO),
+                            coordinates=StringIO(CHOL_GRO),
+                            topology_format="GRO",
+                            trajectory_format="GRO")
+        assert len(u.atoms) == 8
 
-    def test_topology_format(self, kwargs, tmpdir):
-        """Simple test run."""
-        kwargs["topology_format"] = "TPR"
-        with tmpdir.as_cwd():
-            run_analsis(analysis_callable=InterRDF, **kwargs)
+    def test_create_universe_atom_style(self):
+        u = create_universe(topology=StringIO(LAMMPS_NORESID),
+                            topology_format="data",
+                            atom_style="id type x y z")
+        assert u.atoms[0].mass ==  28.0
 
-    def test_atom_style(self, kwargs, tmpdir):
-        """Test the LAMMPS data format."""
-        kwargs["topology"] = StringIO(LAMMPS_NORESID)
-        kwargs["topology_format"] = "data"
-        kwargs["atom_style"] = "id type x y z"
-        kwargs["trajectories"] = None
-        kwargs["g1"] = "all"
-        kwargs["g2"] = "all"
 
-        with tmpdir.as_cwd():
-            ac = run_analsis(analysis_callable=InterRDF, **kwargs)
+# class Test_run_analsis(object):
+#     """Test class for analyze_data."""
 
-        assert len(ac.u.atoms) == 1
-        assert_equal(ac.u.atoms[0].mass, 28.0)
+#     @pytest.fixture()
+#     def kwargs(self):
+#         """Keyword arguments for run."""
+#         kwargs = {}
+#         kwargs["topology"] = TPR
+#         kwargs["topology_format"] = None
+#         kwargs["trajectories"] = XTC
+#         kwargs["trajectory_format"] = None
+#         kwargs["atom_style"] = None
+#         kwargs["begin"] = "0"
+#         kwargs["end"] = "1"
+#         kwargs["dt"] = "1"
+#         kwargs["output_directory"] = "."
+#         kwargs["output_prefix"] = ""
+#         kwargs["verbose"] = False
+#         kwargs["g1"] = "resid 500"  # water molecules
+#         kwargs["g2"] = "resid 501"  # water molecules
 
-    def test_trajectory_format(self, kwargs, tmpdir):
-        """Test for trajectory format."""
-        kwargs["trajectory_format"] = "XTC"
-        with tmpdir.as_cwd():
-            ac = run_analsis(analysis_callable=InterRDF, **kwargs)
-            assert ac._trajectory.format == "XTC"
+#         kwargs["func"] = None
+#         return kwargs
 
-    def test_verbose(self, capsys, kwargs, tmpdir):
-        """Test for being verbose."""
-        kwargs["verbose"] = True
-        with tmpdir.as_cwd():
-            run_analsis(analysis_callable=InterRDF, **kwargs)
-        captured = capsys.readouterr()
-        assert "Loading trajectory..." in captured.out
+#     def test_default(self, kwargs, tmpdir):
+#         """Simple with default arguments."""
+#         with tmpdir.as_cwd():
+#             run_analsis(analysis_callable=InterRDF, **kwargs)
 
-    def test_traj_clices(self, kwargs, tmpdir):
-        """Test for trajectory slicing."""
-        kwargs["begin"] = "1"
-        kwargs["end"] = "10"
-        kwargs["dt"] = "2"
-        with tmpdir.as_cwd():
-            ac = run_analsis(analysis_callable=InterRDF, **kwargs)
-        assert ac.start == 1
-        assert ac.stop == 10
-        assert ac.step == 2
+#     def test_topology_format(self, kwargs, tmpdir):
+#         """Simple test run."""
+#         kwargs["topology_format"] = "TPR"
+#         with tmpdir.as_cwd():
+#             run_analsis(analysis_callable=InterRDF, **kwargs)
+
+#     def test_atom_style(self, kwargs, tmpdir):
+#         """Test the LAMMPS data format."""
+#         kwargs["topology"] = StringIO(LAMMPS_NORESID)
+#         kwargs["topology_format"] = "data"
+#         kwargs["atom_style"] = "id type x y z"
+#         kwargs["trajectories"] = None
+#         kwargs["g1"] = "all"
+#         kwargs["g2"] = "all"
+
+#         with tmpdir.as_cwd():
+#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
+
+#         assert len(ac.u.atoms) == 1
+#         assert_equal(ac.u.atoms[0].mass, 28.0)
+
+#     def test_trajectory_format(self, kwargs, tmpdir):
+#         """Test for trajectory format."""
+#         kwargs["trajectory_format"] = "XTC"
+#         with tmpdir.as_cwd():
+#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
+#             assert ac._trajectory.format == "XTC"
+
+#     def test_verbose(self, capsys, kwargs, tmpdir):
+#         """Test for being verbose."""
+#         kwargs["verbose"] = True
+#         with tmpdir.as_cwd():
+#             run_analsis(analysis_callable=InterRDF, **kwargs)
+#         captured = capsys.readouterr()
+#         assert "Loading trajectory..." in captured.out
+
+#     def test_traj_clices(self, kwargs, tmpdir):
+#         """Test for trajectory slicing."""
+#         kwargs["begin"] = "1"
+#         kwargs["end"] = "10"
+#         kwargs["dt"] = "2"
+#         with tmpdir.as_cwd():
+#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
+#         assert ac.start == 1
+#         assert ac.stop == 10
+#         assert ac.step == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,22 +6,28 @@
 # Released under the GNU Public Licence, v2 or any higher version
 # SPDX-License-Identifier: GPL-2.0-or-later
 """Test mdacli cli."""
+import os
 import subprocess
 import sys
 from io import StringIO
 from unittest.mock import patch
-from MDAnalysis.core.universe import Universe
 
 import pytest
-from MDAnalysis.analysis.rms import RMSF
 from MDAnalysis.analysis.gnm import GNMAnalysis
+from MDAnalysis.analysis.rdf import InterRDF
+from MDAnalysis.analysis.rms import RMSF
+from MDAnalysis.core.universe import Universe
+from MDAnalysisTests.core.test_universe import CHOL_GRO
 from MDAnalysisTests.datafiles import TPR, XTC
 from MDAnalysisTests.topology.test_lammpsdata import LAMMPS_NORESID
-from MDAnalysisTests.core.test_universe import CHOL_GRO
 
-from mdacli.cli import _relevant_modules, setup_clients
-from mdacli.cli import create_universe, convert_analysis_parameters
-
+from mdacli.cli import (
+    _relevant_modules,
+    convert_analysis_parameters,
+    create_universe,
+    run_analsis,
+    setup_clients,
+    )
 from mdacli.libcli import find_AnalysisBase_members_ignore_warnings
 
 
@@ -73,20 +79,26 @@ def test_setup_clients(opt, dest, val):
 
 
 class Test_create_Universe:
+    """Test initilizing mda universes."""
+
     def test_create_universe(self):
+        """Test creating a simple Universe."""
         u = create_universe(TPR, XTC)
         assert len(u.atoms) == 47681
         assert hasattr(u, "trajectory")
 
     def test_topology_format(self):
+        """Test non default topology format."""
         u = create_universe(StringIO(CHOL_GRO), topology_format="GRO")
         assert len(u.atoms) == 8
 
     def test_create_universe_no_traj(self):
+        """Test non trajectpry parsed."""
         u = create_universe(TPR)
         assert not hasattr(u, "trajectory")
 
     def test_trajectory_format(self):
+        """Test non default trajectpry format."""
         u = create_universe(topology=StringIO(CHOL_GRO),
                             coordinates=StringIO(CHOL_GRO),
                             topology_format="GRO",
@@ -94,18 +106,23 @@ class Test_create_Universe:
         assert len(u.atoms) == 8
 
     def test_create_universe_atom_style(self):
+        """Test custom atom style."""
         u = create_universe(topology=StringIO(LAMMPS_NORESID),
                             topology_format="data",
                             atom_style="id type x y z")
-        assert u.atoms[0].mass ==  28.0
+        assert u.atoms[0].mass == 28.0
 
 
 class Test_convert_analysis_parameters:
+    """Test class for converting analysis parameters."""
+
     @pytest.fixture()
     def universe(self):
+        """Univserse fixture."""
         return Universe(TPR, XTC)
 
     def test_Atomgroup(self, universe):
+        """Test AtomGroup conversion."""
         analysis_parameters = {"atomgroup": "all"}
         convert_analysis_parameters(universe,
                                     RMSF,
@@ -113,6 +130,7 @@ class Test_convert_analysis_parameters:
         assert analysis_parameters["atomgroup"] == universe.atoms
 
     def test_Universe(self, universe):
+        """Test Universe conversion."""
         analysis_parameters = {"universe": None}
         convert_analysis_parameters(universe,
                                     GNMAnalysis,
@@ -120,6 +138,7 @@ class Test_convert_analysis_parameters:
         assert analysis_parameters["universe"] == universe
 
     def test_zero_atoms(self, universe):
+        """Test error if zero atoms are present after conversion."""
         analysis_parameters = {"atomgroup": "name foo"}
         with pytest.raises(ValueError, match="AtomGroup `-atomgroup` with "):
             convert_analysis_parameters(universe,
@@ -127,89 +146,124 @@ class Test_convert_analysis_parameters:
                                         analysis_parameters)
 
     def test_only_set_if_key_exists(self, universe):
-        """The docparser does not distinguis between mandatory and positional
-        arguments. So we only should set the value if it is inside the dict."""
+        """
+        Test if keys exist.
+
+        The docparser does not distinguis between mandatory and positional
+        arguments. So we only should set the value if it is inside the dict.
+        """
         analysis_parameters = {}
         convert_analysis_parameters(universe,
                                     RMSF,
                                     analysis_parameters)
         assert not analysis_parameters
 
-# class test_maincli:
-#     pass
 
-# class Test_run_analsis(object):
-#     """Test class for analyze_data."""
+class Test_run_analsis:
+    """Test class for analyze_data."""
 
-#     @pytest.fixture()
-#     def kwargs(self):
-#         """Keyword arguments for run."""
-#         kwargs = {}
-#         kwargs["topology"] = TPR
-#         kwargs["topology_format"] = None
-#         kwargs["trajectories"] = XTC
-#         kwargs["trajectory_format"] = None
-#         kwargs["atom_style"] = None
-#         kwargs["begin"] = "0"
-#         kwargs["end"] = "1"
-#         kwargs["dt"] = "1"
-#         kwargs["output_directory"] = "."
-#         kwargs["output_prefix"] = ""
-#         kwargs["verbose"] = False
-#         kwargs["g1"] = "resid 500"  # water molecules
-#         kwargs["g2"] = "resid 501"  # water molecules
+    @pytest.fixture()
+    def universe_parameters(self):
+        """Universe fixture."""
+        kwargs = {}
+        kwargs["topology"] = TPR
+        kwargs["topology_format"] = None
+        kwargs["coordinates"] = XTC
+        kwargs["trajectory_format"] = None
+        kwargs["atom_style"] = None
+        return kwargs
 
-#         kwargs["func"] = None
-#         return kwargs
+    @pytest.fixture()
+    def mandatory_parameters(self):
+        """Mandatory parameter fixture."""
+        kwargs = {}
+        kwargs["g1"] = "resid 500"  # water molecules
+        kwargs["g2"] = "resid 501"  # water molecules
+        return kwargs
 
-#     def test_default(self, kwargs, tmpdir):
-#         """Simple with default arguments."""
-#         with tmpdir.as_cwd():
-#             run_analsis(analysis_callable=InterRDF, **kwargs)
+    def test_default(self,
+                     universe_parameters,
+                     mandatory_parameters,
+                     tmpdir):
+        """Test with default arguments."""
+        with tmpdir.as_cwd():
+            run_analsis(analysis_callable=InterRDF,
+                        universe_parameters=universe_parameters,
+                        mandatory_analysis_parameters=mandatory_parameters)
 
-#     def test_topology_format(self, kwargs, tmpdir):
-#         """Simple test run."""
-#         kwargs["topology_format"] = "TPR"
-#         with tmpdir.as_cwd():
-#             run_analsis(analysis_callable=InterRDF, **kwargs)
+    def test_optional_paramaters(self,
+                                 universe_parameters,
+                                 mandatory_parameters,
+                                 tmpdir):
+        """Test with optional parameters given."""
+        opt_params = {"nbins": 100}
+        with tmpdir.as_cwd():
+            a = run_analsis(analysis_callable=InterRDF,
+                            universe_parameters=universe_parameters,
+                            mandatory_analysis_parameters=mandatory_parameters,
+                            optional_analysis_parameters=opt_params)
 
-#     def test_atom_style(self, kwargs, tmpdir):
-#         """Test the LAMMPS data format."""
-#         kwargs["topology"] = StringIO(LAMMPS_NORESID)
-#         kwargs["topology_format"] = "data"
-#         kwargs["atom_style"] = "id type x y z"
-#         kwargs["trajectories"] = None
-#         kwargs["g1"] = "all"
-#         kwargs["g2"] = "all"
+        assert a.rdf_settings["bins"] == opt_params["nbins"]
 
-#         with tmpdir.as_cwd():
-#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
+    def test_verbose(self,
+                     universe_parameters,
+                     mandatory_parameters,
+                     tmpdir,
+                     capsys):
+        """Test for being verbose."""
+        run_parameters = {"verbose": True}
+        with tmpdir.as_cwd():
+            run_analsis(analysis_callable=InterRDF,
+                        universe_parameters=universe_parameters,
+                        mandatory_analysis_parameters=mandatory_parameters,
+                        run_parameters=run_parameters)
+        captured = capsys.readouterr()
+        assert "Loading trajectory..." in captured.out
 
-#         assert len(ac.u.atoms) == 1
-#         assert_equal(ac.u.atoms[0].mass, 28.0)
+    def test_custom_output(self,
+                           universe_parameters,
+                           mandatory_parameters,
+                           tmpdir):
+        """Test for custom output."""
+        output_parameters = {"output_directory": "foo",
+                             "output_prefix": "bar"}
 
-#     def test_trajectory_format(self, kwargs, tmpdir):
-#         """Test for trajectory format."""
-#         kwargs["trajectory_format"] = "XTC"
-#         with tmpdir.as_cwd():
-#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
-#             assert ac._trajectory.format == "XTC"
+        with tmpdir.as_cwd():
+            os.mkdir("foo")
+            run_analsis(analysis_callable=InterRDF,
+                        universe_parameters=universe_parameters,
+                        mandatory_analysis_parameters=mandatory_parameters,
+                        output_parameters=output_parameters)
 
-#     def test_verbose(self, capsys, kwargs, tmpdir):
-#         """Test for being verbose."""
-#         kwargs["verbose"] = True
-#         with tmpdir.as_cwd():
-#             run_analsis(analysis_callable=InterRDF, **kwargs)
-#         captured = capsys.readouterr()
-#         assert "Loading trajectory..." in captured.out
+            os.path.isfile(os.path.join("foo",
+                                        "bar_InterRDF_count_bins_rdf.csv"))
 
-#     def test_traj_clices(self, kwargs, tmpdir):
-#         """Test for trajectory slicing."""
-#         kwargs["begin"] = "1"
-#         kwargs["end"] = "10"
-#         kwargs["dt"] = "2"
-#         with tmpdir.as_cwd():
-#             ac = run_analsis(analysis_callable=InterRDF, **kwargs)
-#         assert ac.start == 1
-#         assert ac.stop == 10
-#         assert ac.step == 2
+    def test_output_directory(self,
+                              universe_parameters,
+                              mandatory_parameters,
+                              tmpdir):
+        """Test for custom output directory."""
+        output_parameters = {"output_directory": "foo"}
+        with tmpdir.as_cwd():
+            os.mkdir("foo")
+            run_analsis(analysis_callable=InterRDF,
+                        universe_parameters=universe_parameters,
+                        mandatory_analysis_parameters=mandatory_parameters,
+                        output_parameters=output_parameters)
+
+            os.path.isfile(os.path.join("foo", "InterRDF_count_bins_rdf.csv"))
+
+    def test_output_prefix(self,
+                           universe_parameters,
+                           mandatory_parameters,
+                           tmpdir):
+        """Test for custom prefix."""
+        output_parameters = {"output_prefix": "foo"}
+        with tmpdir.as_cwd():
+            os.mkdir("foo")
+            run_analsis(analysis_callable=InterRDF,
+                        universe_parameters=universe_parameters,
+                        mandatory_analysis_parameters=mandatory_parameters,
+                        output_parameters=output_parameters)
+
+            os.path.isfile("foo_InterRDF_count_bins_rdf.csv")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@
 # Released under the GNU Public Licence, v2 or any higher version
 # SPDX-License-Identifier: GPL-2.0-or-later
 """Test mdacli cli."""
+import argparse
 import os
 import subprocess
 import sys
@@ -73,7 +74,9 @@ def test_setup_clients(opt, dest, val):
     members = find_AnalysisBase_members_ignore_warnings(_relev_mod)
 
     with patch.object(sys, 'argv', testargs):
-        args = setup_clients(title='title', members=members).parse_args()
+        ap = argparse.ArgumentParser()
+        setup_clients(ap, title='title', members=members)
+        args = ap.parse_args()
         t = type(val)
         assert t(getattr(args, dest)) == val
 

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -92,7 +92,7 @@ def test_find_AnalysisBase_members_None():
     assert members is None
 
 
-def split_argparse_into_groups():
+def test_split_argparse_into_groups():
     """Test splitting argparse Namespace into several dicts."""
     parser = argparse.ArgumentParser()
 
@@ -104,7 +104,7 @@ def split_argparse_into_groups():
 
     args = parser.parse_args('--test1 one --test2 two'.split())
 
-    arg_grouped_dict = split_argparse_into_groups(parser, args)
+    arg_grouped_dict = libcli.split_argparse_into_groups(parser, args)
 
     assert arg_grouped_dict["group1"]["test1"] == "one"
     assert arg_grouped_dict["group2"]["test2"] == "two"

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -91,8 +91,9 @@ def test_find_AnalysisBase_members_None():
 
     assert members is None
 
-def split_argparse_into_groups():
 
+def split_argparse_into_groups():
+    """Test splitting argparse Namespace into several dicts."""
     parser = argparse.ArgumentParser()
 
     group1 = parser.add_argument_group('group1')

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -90,3 +90,20 @@ def test_find_AnalysisBase_members_None():
     members = libcli.find_classes_in_modules(AnalysisBase, "MDAnalysis")
 
     assert members is None
+
+def split_argparse_into_groups():
+
+    parser = argparse.ArgumentParser()
+
+    group1 = parser.add_argument_group('group1')
+    group1.add_argument('--test1', help="test1")
+
+    group2 = parser.add_argument_group('group2')
+    group2.add_argument('--test2', help="test2")
+
+    args = parser.parse_args('--test1 one --test2 two'.split())
+
+    arg_grouped_dict = split_argparse_into_groups(parser, args)
+
+    assert arg_grouped_dict["group1"]["test1"] == "one"
+    assert arg_grouped_dict["group2"]["test2"] == "two"


### PR DESCRIPTION
Fixes #33
Fixes #34
Fixes #43

I restructured the `run_analsis` function and factored out two functions: 

1. `create_universe` creating and returning the universe
2. `convert_analysis_parameters`, converting the parameters from the cli into ones suitable for the analysis instance. 

The most painful work is to split the arguments from the command line into individual dictionaries. argparse does not allow this by default and my way is a bit hacky...

## TODOs
* [x] Tests
* [x] documentation