### PR TITLE
Corrects bumps subtitle in changelog

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -24,5 +24,9 @@ search = version = release = '{current_version}'
 replace = version = release = '{new_version}'
 
 [bumpversion:file:docs/CHANGELOG.rst]
-search = new_version
-replace = v{new_version} ({now:%Y-%m-%d})
+search = 
+    new_version
+    -----------
+replace = 
+    v{new_version} ({now:%Y-%m-%d})
+    ------------------------------------------

--- a/.github/workflows/version-bump-and-package.yml
+++ b/.github/workflows/version-bump-and-package.yml
@@ -75,4 +75,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --verbose dist/*

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
-v0.1.0 (2021-11-18)
+new_version
 -----------
+
+* corrects .bumpversion.cfg for CHANGELOG
+* updates docs/CONTRIBUTING.rst accordingly
+
+v0.1.0 (2021-11-18)
+-------------------
 * Initial release

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -128,13 +128,16 @@ version subtitle::
     =========
 
     new_version
-    ----------------
+    -----------
 
     * here goes my new additions
     * explain them shortly and well
 
     vX.X.X (1900-01-01)
     -------------------
+
+Note to add the correct amount of `---` dashes before the `new_version`
+subtitle.
 
 Also add your name to the authors list at :code:`docs/AUTHORS.rst`.
 


### PR DESCRIPTION
Should solve the error from the previous #61. Commit message should be without any tag.