### PR TITLE
Improves and corrects regex to convert string to timestep and frames

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+new_version
+-----------
+* Improves regex to convert from time to frame (#81)
+
 v0.1.6 (2021-12-01)
 -------------------------------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,9 +6,11 @@
 # Released under the GNU Public Licence, v2 or any higher version
 # SPDX-License-Identifier: GPL-2.0-or-later
 """Test mdacli utils."""
+from math import isclose
+
 import pytest
 
-from mdacli.utils import _exit_if_a_is_b, convert_str_time
+from mdacli.utils import _exit_if_a_is_b, convert_str_time, split_time_unit
 
 
 def test__exit_if_a_is_b():
@@ -23,6 +25,7 @@ def test__exit_if_a_is_b():
                          (('1', 1),
                           ('-1', -1),
                           ('1ns', 1000),
+                          ('1.5ns', 1500),
                           ('12e3', 12e3),
                           ('12e3ps', 12e3)))
 def test_convert_str_time(x, frame):
@@ -39,3 +42,55 @@ def test_convert_str_time_raise():
     """Test convert string to time ValueError."""
     with pytest.raises(ValueError):
         convert_str_time('0.1', dt=1)
+
+
+@pytest.mark.parametrize(
+    's,expected',
+    [
+        ['00', (0.0, '')],
+        ['0', (0.0, '')],
+        ['-0', (0.0, '')],
+        ['0.', (0.0, '')],
+        ['.0ns', (0.0, 'ns')],
+        ['12.3ps', (12.3, 'ps')],
+        ['12.34minute', (12.34, 'minute')],
+        ['-12.34', (-12.34, '')],
+        ['10E40sd', (float('10E40'), 'sd')],
+        ['1E4', (float('1E4'), '')],
+        ['1E-4hours', (float('1E-4'), 'hours')],
+        ['-10E40nanosecond', (float('-10E40'), 'nanosecond')],
+        ['-10E-40', (float('-10E-40'), '')],
+        ['-.1E-4', (float('-.1E-4'), '')],
+        ['10.2E30', (float('10.2E30'), '')],
+        ['.10E30', (float('.10E30'), '')],
+        ['-10.2E30', (float('-10.2E30'), '')],
+        ['-.10E30', (float('-.10E30'), '')],
+        ]
+    )
+def test_string_to_timestep(s, expected):
+    """Test correct conversion."""
+    time_, unit_ = split_time_unit(s)
+    assert isclose(time_, expected[0])
+    assert unit_ == expected[1]
+
+
+@pytest.mark.parametrize(
+    's',
+    [
+        '12.34 # with comment',
+        '12.34.12fdsfdsfds',
+        '1E4.4',
+        '.10E30E',
+        '10.2.E30',
+        '123#with wrong comment',
+        'E10',
+        '.E10',
+        '-e',
+        '-E10',
+        '10-10E19',
+        ]
+    )
+def test_string_to_timestep_wrong(s):
+    """Test correct conversion."""
+    with pytest.raises(IndexError):
+        split_time_unit(s)


### PR DESCRIPTION
Improves and corrects regex to convert string to timestep and frames.
The previous regex was evaluated as follows: https://regex101.com/r/nWH1qJ/1/. I think the match groups are not correct and would open the door to errors, bugs, or unpleasant user experience.

Here is an improved regular expression: https://regex101.com/r/LZAbil/2. The separation between numbers and units is cleaner and strange numbers are not parsed at all. I originally implemented this regex in https://github.com/haddocking/haddock3/pull/81 and now updated it https://github.com/haddocking/haddock3/pull/174. Kudos to @PicoCentauri for that lower case `e` in the scientific notation.

Also decouples the regex parsing and the time to frame conversion. +1 to modularity, encapsulation, and testability :wink:

Adds tests to cover for all new functionality. The previous API is maintained, so the version bump is `patch`.