### PR TITLE
Reenable docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,59 +21,59 @@ jobs:
     - name: Build docs
       run: tox -e docs
 
-    # - name: Deploy docs
-    #   if: github.event_name != 'pull_request'
-    #   env:
-    #     GH_USER: github-actions
-    #     GH_EMAIL: "github-action@users.noreply.github.com"
-    #     GH_REPOSITORY: "github.com/${{ github.repository }}.git"
-    #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     URL: https://mdacli.mdanalysis.org
+    - name: Deploy docs
+      if: github.event_name != 'pull_request'
+      env:
+        GH_USER: github-actions
+        GH_EMAIL: "github-action@users.noreply.github.com"
+        GH_REPOSITORY: "github.com/${{ github.repository }}.git"
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        URL: https://mdacli.mdanalysis.org
 
-    #   run: |
-    #     # set up environment variables
-    #     # export URL for the Python script $UPDATE_JSON
-    #     export VERSION=$(grep __version__ src/mdacli/__init__.py | awk '{print $3}' | tr -d "'")
-    #     UPDATE_JSON=$(pwd)/devtools/update_json_stubs_sitemap.py
-    #     BRANCH="${GITHUB_REF#refs/heads/}"
+      run: |
+        # set up environment variables
+        # export URL for the Python script $UPDATE_JSON
+        export VERSION=$(grep __version__ src/mdacli/__init__.py | awk '{print $3}' | tr -d "'")
+        UPDATE_JSON=$(pwd)/devtools/update_json_stubs_sitemap.py
+        BRANCH="${GITHUB_REF#refs/heads/}"
 
-    #     # the below turns off non-blocking as it causes large writes to stdout to fail
-    #     # (see https://github.com/travis-ci/travis-ci/issues/4704)
-    #     # commented out as this is not a problem with gh-actions
-    #     # python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+        # the below turns off non-blocking as it causes large writes to stdout to fail
+        # (see https://github.com/travis-ci/travis-ci/issues/4704)
+        # commented out as this is not a problem with gh-actions
+        # python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
         
-    #     # go into built docs
-    #     cd dist/docs
+        # go into built docs
+        cd dist/docs
 
-    #     # move docs into version subfolder
-    #     mkdir ../${VERSION} && mv * ../${VERSION} && mv ../${VERSION} $VERSION
+        # move docs into version subfolder
+        mkdir ../${VERSION} && mv * ../${VERSION} && mv ../${VERSION} $VERSION
 
-    #     # set up git
-    #     REV=$(git rev-parse --short HEAD)
-    #     git init
-    #     git config user.name $GH_USER
-    #     git config user.email $GH_EMAIL
-    #     git remote add upstream "https://${GH_USER}:${GH_TOKEN}@${GH_REPOSITORY}"
-    #     git fetch --depth 50 upstream $BRANCH gh-pages
-    #     git reset upstream/gh-pages
+        # set up git
+        REV=$(git rev-parse --short HEAD)
+        git init
+        git config user.name $GH_USER
+        git config user.email $GH_EMAIL
+        git remote add upstream "https://${GH_USER}:${GH_TOKEN}@${GH_REPOSITORY}"
+        git fetch --depth 50 upstream $BRANCH gh-pages
+        git reset upstream/gh-pages
 
-    #     # redirects and copies
-    #     mkdir latest
-    #     python $UPDATE_JSON --version $VERSION --url $URL
-    #     touch .
-    #     touch .nojekyll
+        # redirects and copies
+        mkdir latest
+        python $UPDATE_JSON --version $VERSION --url $URL
+        touch .
+        touch .nojekyll
 
-    #     # add this particular version's files
-    #     git add -A ${VERSION}/
-    #     git add .nojekyll versions.json *.xml *.html index.html latest
+        # add this particular version's files
+        git add -A ${VERSION}/
+        git add .nojekyll versions.json *.xml *.html index.html latest
 
-    #     # add other versions, e.g. stable. If a dev branch is added, add dev too
-    #     for dirname in stable dev ; do
-    #       if [ -d $dirname ]; then git add $dirname; fi
-    #     done
+        # add other versions, e.g. stable. If a dev branch is added, add dev too
+        for dirname in stable dev ; do
+          if [ -d $dirname ]; then git add $dirname; fi
+        done
 
-    #     # check for anything to commit
-    #     # https://stackoverflow.com/questions/3878624/how-do-i-programmatically-determine-if-there-are-uncommited-changes
-    #     # then push to gh-pages for build
-    #     git diff-index --quiet HEAD -- || git commit -m "rebuilt html docs for version ${VERSION} from branch ${BRANCH} with sphinx at ${REV}"
-    #     git push -q upstream HEAD:gh-pages
+        # check for anything to commit
+        # https://stackoverflow.com/questions/3878624/how-do-i-programmatically-determine-if-there-are-uncommited-changes
+        # then push to gh-pages for build
+        git diff-index --quiet HEAD -- || git commit -m "rebuilt html docs for version ${VERSION} from branch ${BRANCH} with sphinx at ${REV}"
+        git push -q upstream HEAD:gh-pages

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* Reenable docs on https://mdacli.mdanalysis.org
 
 v0.1.25 (2023-02-21)
 ------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,17 @@ authors = [
 ]
 readme = "README.rst"
 requires-python = ">=3.8"
-keywords = ["Science", "Molecular Dynamics", "MDAnalysis"]
+keywords = [
+    "python",
+    "cli",
+    "science",
+    "command-line",
+    "molecular-dynamics",
+    "computational-chemistry",
+    "molecular-dynamics-simulation",
+    "command-line-tool",
+    "trajectory-analysis mdanalysis",
+]
 license = {text = "GPL-3.0-or-later"}
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/MDAnalysis/mdacli"
-documentation = "https://mdacli.readthedocs.io/en/latest"
+homepage = "https://mdacli.mdanalysis.org"
+documentation = "https://mdacli.mdanalysis.org"
 repository = "https://github.com/MDAnalysis/mdacli"
 changelog = "https://github.com/MDAnalysis/mdacli/blob/main/docs/CHANGELOG.rst"
 issues = "https://github.com/MDAnalysis/mdacli/issues/"


### PR DESCRIPTION
Fixes #103
Fixes #104

Try to re-enable the deployment of the docs on https://mdacli.mdanalysis.org.

I restored the `gh-pages` branch from a backup. Maybe @lilyminium can check if this should still work.