### PR TITLE
Add canonical name for `AtomGroup` and `Universe`

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* Make the canonical names of mda types parsable.
 
 v0.1.25 (2023-02-21)
 ------------------------------------------

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -38,7 +38,9 @@ STR_TYPE_DICT = {
     "complex": complex,
     "NoneType": None,
     "AtomGroup": mda.AtomGroup,
+    "MDAnalysis.core.groups.AtomGroup": mda.AtomGroup,
     "list[AtomGroup]": List[mda.AtomGroup],
+    "MDAnalysis.core.universe.Universe": mda.Universe,
     "Universe": mda.Universe,
     }
 

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -676,7 +676,8 @@ def convert_analysis_parameters(analysis_callable,
 
     for param_name, dictionary in params.items():
         if param_name in analysis_parameters_keys:
-            if "AtomGroup" == dictionary['type']:
+            if dictionary['type'] in ["AtomGroup",
+                                      "MDAnalysis.core.groups.AtomGroup"]:
                 sel = analysis_parameters[param_name]
                 # Do not try to parse `None` value
                 # They could be default arguments of a function
@@ -701,7 +702,8 @@ def convert_analysis_parameters(analysis_callable,
                                          f"string of the selection {sel}` "
                                          f"does not contain any atoms.")
 
-            elif "Universe" == dictionary['type']:
+            elif dictionary['type'] in ["Universe",
+                                        "MDAnalysis.core.universe.Universe"]:
                 # Create universe parameter dictionary from signature
                 sig = inspect.signature(create_universe)
                 universe_parameters = dict(sig.parameters)

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -243,7 +243,7 @@ def parse_docs(klass):
     desc_tmp = []
 
     # regex to find parameter types
-    type_regex = re.compile(r'^([\[\]\w]+|\{.*\})|(?<=\`\~)(.*?)(?=\`)')
+    type_regex = re.compile(r'^([\[\]\w\.]+|\{.*\})|(?<=\`\~)(.*?)(?=\`)')
 
     # goes back to front to register descriptions first ;-)
     # considers only the Parameters section

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -662,6 +662,7 @@ class Test_create_cli():
                               ("complex", complex, 1j),
                               ("NoneType", None, None),
                               ("AtomGroup", str, None),
+                              ('MDAnalysis.core.groups.AtomGroup', str, None),
                               ("list[AtomGroup]", str, None)])
     def test_arguments(self, parameters, argument, val_type, arg_type, value):
         """Test for existance and default value of arguments."""


### PR DESCRIPTION
The analysis modules of MDA are a bit inconsistent. Because of this, some modules do not work as they define the type of `atomgroup` as `MDAnalysis.core.groups.AtomGroup`. This should be supported in my opinion.