### PR TITLE
Fix lowercase names

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -2,10 +2,10 @@
 Changelog
 =========
 
+* Change handling of lowercase module names
 
 v0.1.28 (2023-09-29)
 ------------------------------------------
-
 
 * Make choices style parsable (#114) 
 

--- a/src/mdacli/__main__.py
+++ b/src/mdacli/__main__.py
@@ -10,8 +10,9 @@
 A command line interface (CLI) to the analysis modules of MDAnalysis.
 
 The modules are all structured as part of a single mdacli wrapper, and invoked
-with commands like `mda RMSD`. This command uses the class
-:class:`MDAnalysis.analysis.rms.RMSD` for calculating the RMSD.
+with commands like `mda RMSD` (The lowercase `mda rmsd` is also supported).
+This command uses the class :class:`MDAnalysis.analysis.rms.RMSD` for
+calculating the RMSD.
 Documentation for each module can be found at the respective sections on the
 `MDAnalysis Documentation`_, as well as
 `mda command -h`.

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -102,9 +102,6 @@ def cli(name,
     #   sub parser in complete detail.
     setup_clients(ap, title=f"{name} Analysis Modules", members=modules)
 
-    # Be case insensitive for the subcommand
-    sys.argv[1] = sys.argv[1].lower()
-
     args = ap.parse_args()
 
     if args.debug:

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -117,7 +117,7 @@ def cli(name,
 
             # Get the correct ArgumentParser instance from all subparsers
             # `[0]` selects the first subparser where our analysises live in.
-            _key = analysis_callable.__name__.lower()
+            _key = analysis_callable.__name__
             ap_sup = ap._subparsers._group_actions[0].choices[_key]
             arg_grouped_dict = split_argparse_into_groups(ap_sup, args)
 

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -367,6 +367,7 @@ def create_cli(sub_parser, interface_name, parameters):
     # creates the subparser
     analysis_class_parser = sub_parser.add_parser(
         interface_name,
+        aliases=[interface_name.lower()],
         help=parameters["desc"],
         description=f"{parameters['desc']}\n\n{parameters['desc_long']}",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -767,7 +767,7 @@ def setup_clients(ap, title, members):
     # to be writen
     for member_name, parameters in analysis_interfaces.items():
         create_cli(sub_parser=cli_subparser,
-                   interface_name=member_name.lower(),
+                   interface_name=member_name,
                    parameters=parameters)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,12 @@ def test_case_insensitive(args):
     """Test for beeing case insensitive."""
     subprocess.check_call(['mda', args, "-h"])
 
+@pytest.mark.parametrize('args', ("RMSF", "rmsf"))
+def test_case_insensitive_with_flags(args):
+    """Test for module name being case insensitive with additional flags."""
+    # Check if it still works if the module name is not the second argument
+    subprocess.check_call(['mda', '--debug', args, "-h"])
+
 
 def test_running_analysis(tmpdir):
     """Test running a complete analysis."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ def test_case_insensitive(args):
     """Test for beeing case insensitive."""
     subprocess.check_call(['mda', args, "-h"])
 
+
 @pytest.mark.parametrize('args', ("RMSF", "rmsf"))
 def test_case_insensitive_with_flags(args):
     """Test for module name being case insensitive with additional flags."""


### PR DESCRIPTION
The currently hardcoded lowercasing of the subparser name breaks very fast and workaround are ugly. One way around that would be adding aliases to the subparsers.